### PR TITLE
Link uploads and --no-copy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Usage:
 
 The commands are:
 
-  upload     uploads media (filepath is required)
+  upload     uploads media (filepath/url is required)
+    --no-copy to skip copying the result link
   delete     deletes all media files
   list       prints all uploaded media
 

--- a/qs_test
+++ b/qs_test
@@ -29,7 +29,7 @@ failure() {
 test_upload() {
   "${qs}" delete
 
-  output=$("${qs}" upload <(base64 -d <<< "${image}"))
+  output=$("${qs}" upload <(base64 -d <<< "${image}") 2>&1 1>/dev/null)
   [[ "${output}" =~ "Media uploaded" ]] || return 1
 }
 


### PR DESCRIPTION
- Support uploading remote content (only HTTPS links are supported)
- Add `--no-copy` flag to skip copying the result link
- Output only the result link to STDOUT; all other messages go to STDERR